### PR TITLE
Fixed darkmode list rendering bug

### DIFF
--- a/script.js
+++ b/script.js
@@ -404,7 +404,9 @@ const search = {
       if (list) search.renderList(list, insert, hint);
     }
   },
-  renderList: (list, insert, hint = "") => {
+    renderList: (list, insert, hint = "") => {
+    // check if it's in darkmode
+    search.checkDarkMode();
     //render suggestions list
     //client side sorting:
     if (hint !== "") {


### PR DESCRIPTION
Hi, i've fixed an issue when rendering a new search after pressing esc key in the search bar in darkmode. Previously when the user tried to do a new search the list didn't reset the rendering color, like in the screenshots.

![list-issue](https://user-images.githubusercontent.com/15681084/204116337-e29afeac-7aae-487a-8b28-62503f4664b7.png)
![Screenshot 2022-11-26 231430](https://user-images.githubusercontent.com/15681084/204116350-f0cf302b-6926-4ff3-a4de-e65fc27285b7.png)
